### PR TITLE
Replace '.' with '_' in task id

### DIFF
--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -58,8 +58,8 @@ std::string getTaskId(const TaskPrivate* task) {
 	char our_hostname[256] = { 0 };
 	gethostname(our_hostname, sizeof(our_hostname) - 1);
 
-	// Hostname could have characters that are invalid in ROS so we replace them it with `_`
-	std::vector<char> invalid_characters = {'-','.'};
+	// Hostname could have characters that are invalid in ROS so we replace them with `_`
+	std::vector<char> invalid_characters = { '-', '.' };
 	for (auto & character : invalid_characters) {
 		std::replace(std::begin(our_hostname), std::end(our_hostname), character, '_');
 	}

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -60,7 +60,7 @@ std::string getTaskId(const TaskPrivate* task) {
 
 	// Hostname could have characters that are invalid in ROS so we replace them with `_`
 	std::vector<char> invalid_characters = { '-', '.' };
-	for (auto & character : invalid_characters) {
+	for (auto& character : invalid_characters) {
 		std::replace(std::begin(our_hostname), std::end(our_hostname), character, '_');
 	}
 

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -57,8 +57,13 @@ std::string getTaskId(const TaskPrivate* task) {
 	std::ostringstream oss;
 	char our_hostname[256] = { 0 };
 	gethostname(our_hostname, sizeof(our_hostname) - 1);
-	// Hostname could have `-` as a character but this is an invalid character in ROS so we replace it with `_`
-	std::replace(std::begin(our_hostname), std::end(our_hostname), '-', '_');
+
+	// Hostname could have characters that are invalid in ROS so we them it with `_`
+  std::vector<char> invalid_characters = {'-','.'};
+  for (auto & character : invalid_characters) {
+    std::replace(std::begin(our_hostname), std::end(our_hostname), character, '_');
+  }
+
 	oss << our_hostname << "_" << getpid() << "_" << reinterpret_cast<std::size_t>(task);
 	return oss.str();
 }

--- a/core/src/introspection.cpp
+++ b/core/src/introspection.cpp
@@ -58,11 +58,11 @@ std::string getTaskId(const TaskPrivate* task) {
 	char our_hostname[256] = { 0 };
 	gethostname(our_hostname, sizeof(our_hostname) - 1);
 
-	// Hostname could have characters that are invalid in ROS so we them it with `_`
-  std::vector<char> invalid_characters = {'-','.'};
-  for (auto & character : invalid_characters) {
-    std::replace(std::begin(our_hostname), std::end(our_hostname), character, '_');
-  }
+	// Hostname could have characters that are invalid in ROS so we replace them it with `_`
+	std::vector<char> invalid_characters = {'-','.'};
+	for (auto & character : invalid_characters) {
+		std::replace(std::begin(our_hostname), std::end(our_hostname), character, '_');
+	}
 
 	oss << our_hostname << "_" << getpid() << "_" << reinterpret_cast<std::size_t>(task);
 	return oss.str();


### PR DESCRIPTION
This pull request will allow host names which contain the character '.' to successfully create MTC tasks.