### PR TITLE
Use trajectory execution info from parent only if controller list is empty

### DIFF
--- a/core/src/container.cpp
+++ b/core/src/container.cpp
@@ -365,7 +365,9 @@ void ContainerBase::insert(Stage::pointer&& stage, int before) {
 	if (!stage)
 		throw std::runtime_error(name() + ": received invalid stage pointer");
 
-	stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+	if (stage->trajectoryExecutionInfo().controller_names.empty()) {
+		stage->setTrajectoryExecutionInfo(this->trajectoryExecutionInfo());
+	}
 
 	StagePrivate* impl = stage->pimpl();
 	impl->setParent(this);


### PR DESCRIPTION
Small fix for defining execution controllers per MTC stage. Without this change, controller configurations per stage will be overwritten by task-global settings